### PR TITLE
Add inbound call handling to D-Modem

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,32 @@
+# Plan for Adding Incoming Call Support to D-Modem
+
+## Overview
+The current implementation places outbound SIP calls from `d-modem` and is invoked on demand by `slmodemd`. There is no mechanism for registering with a SIP server or handling unsolicited inbound calls. `slmodemd` launches `d-modem` only when dialing a number, and the data socket carries only audio frames.
+
+To support receiving calls, we need a long-lived `d-modem` process that registers with the SIP server, reports incoming call events to `slmodemd`, and answers when the user issues `ATA`.
+
+## Proposed Changes
+
+### 1. Extend `d-modem.c`
+- **Add SIP registration for listening**: `pjsua_acc_config` currently disables auto-registration (`cfg.register_on_acc_add = false` at line 236 of `d-modem.c`). Enable registration or call `pjsua_acc_set_registration` so the account can receive calls.
+- **Incoming call callback**: Add `cfg.cb.on_incoming_call` to `pjsua_config` and implement a handler that reports the event to `slmodemd` instead of immediately placing a call.
+- **Command channel**: Accept an additional file descriptor for control messages. Use it to notify `slmodemd` of `RING`, `CONNECT`, and `DISCONNECT` and to receive commands (`ANSWER`, `DIAL`, `HANGUP`).
+- **Listening mode**: Allow starting `d-modem` without a dial string (e.g., `d-modem --listen <audio-fd> <ctrl-fd>`). In this mode, skip the `pjsua_call_make_call` section (lines 248‑254) and wait for incoming calls.
+- **Answering calls**: When control channel receives an `ANSWER` command, call `pjsua_call_answer` to accept the pending call and connect audio using existing media callbacks (`on_call_media_state`).
+
+### 2. Modify `slmodemd` (`modem_main.c` and `modem.c`)
+- **Startup**: Spawn `d-modem` in listening mode during `socket_start` and pass both the audio and new control sockets via `execl`.
+- **Control channel management**: Track the control socket in a global descriptor and monitor it in `modem_run` to receive signalling messages (`RING`, `DISCONNECT`).
+- **Command helper**: Provide a global `dmodem_command()` helper so other modules can send text commands to `d-modem` without direct access to the socket.
+- **Ring and hangup handling**: `modem_run` calls `modem_ring` when a `RING` message is received and `modem_remote_hangup` on `DISCONNECT`.
+- **Answer, dial, and hangup commands**: `modem_answer`, `modem_dial`, and the local branch of `modem_hup` send `ANSWER`, `DIAL <number>`, and `HANGUP` commands respectively through `dmodem_command()`.
+
+### 3. Documentation and Build Scripts
+- Update `README.md` to describe new inbound-call capability and how to run `slmodemd`/`d-modem` in listening mode.
+- Adjust `Makefile` if new source files or compilation flags are required (e.g., for control channel helper).
+
+## Testing
+- Build the project with `make` to ensure new files compile.
+- Simulate an inbound call to verify `RING` notifications appear on the TTY and that `ATA` answers the call.
+- Confirm outbound calling continues to work using existing procedures.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Connect to dialup modems over VoIP using SIP, no modem hardware required.
 https://www.aon.com/cyber-solutions/aon_cyber_labs/introducing-d-modem-a-software-sip-modem/
 
 ## Building
-You'll need Linux and a working 32-bit development environment (gcc -m32 needs to work, Debian-based systems can install libc6-dev-i386), along with PJSIP's dependencies (OpenSSL).  Then run 'make' from the top-level directory.
+You'll need Linux along with PJSIP's dependencies (OpenSSL).  The SmartLink DSP library only ships as 32-bit object code, so building requires 32-bit support (e.g., gcc-multilib).  Run `make` from the top-level directory.
 
 ## How it Works
 Traditional “controller-based” modems generally used a microcontroller and a DSP to handle all aspects of modem communication on the device itself.  Later, so-called “Winmodems” were introduced that allowed for field-programmable DSPs and moved the controller and other functionality into software running on the host PC.  This was followed by “pure software” modems that moved DSP functionality to the host as well.  The physical hardware of these softmodems was only used to connect to the phone network, and all processing was done in software. 
@@ -58,14 +58,27 @@ Finally, dial the number of the target system.  Below shows a connection to the 
     59515 21-10-28 21:40:19 11 0 -.1 045.0 UTC(NIST) * 
     59515 21-10-28 21:40:20 11 0 -.1 045.0 UTC(NIST) * 
     59515 21-10-28 21:40:21 11 0 -.1 045.0 UTC(NIST) * 
-    59515 21-10-28 21:40:22 11 0 -.1 045.0 UTC(NIST) * 
+    59515 21-10-28 21:40:22 11 0 -.1 045.0 UTC(NIST) *
     59515 21-10-28 21:40:23 11 0 -.1 045.0 UTC(NIST) *
- 
+
+### Calling between two D-Modem clients
+
+The `d-modem` helper launched by `slmodemd` registers your SIP account and waits for incoming calls.
+When a call arrives, the terminal prints `RING` and you can answer with `ATA` or hang up with `ATH`.
+
+To connect two clients together:
+
+1. On each machine set `SIP_LOGIN` to credentials for SIP accounts that can call each other.
+2. Start `slmodemd` pointing at `d-modem` and open the created `/dev/ttySL0` with a terminal program.
+3. Disable dial tone detection (`ATX3`) and set the desired modulation (`AT+MS=...`) on both ends.
+4. From the calling side issue `ATD` with the callee's SIP URI or number.
+5. The receiving side will show `RING`; answer with `ATA`.
+6. Either side can terminate the call with `ATH`.
+
 ## Known Issues / Future Work
-- Connections are unreliable, and it is currently difficult to connect at speeds higher than 14.4kbps or so.  It might be possible to improve this by disabling/reconfiguring PJSIP’s jitter buffer. 
-- Additional logging/error handling is needed 
-- The serial interface could be replaced with stdio or a socket, and common AT configuration options could be exposed as command line options 
-- There is currently no support for receiving calls 
+- Connections are unreliable, and it is currently difficult to connect at speeds higher than 14.4kbps or so.  It might be possible to improve this by disabling/reconfiguring PJSIP’s jitter buffer.
+- Additional logging/error handling is needed
+- The serial interface could be replaced with stdio or a socket, and common AT configuration options could be exposed as command line options
 
 
 Copyright 2021 Aon plc

--- a/d-modem.c
+++ b/d-modem.c
@@ -22,6 +22,8 @@
 #include <stdio.h>
 #include <signal.h>
 #include <errno.h>
+#include <string.h>
+#include <sys/select.h>
 
 #include <pjsua-lib/pjsua.h>
 
@@ -36,6 +38,10 @@ struct dmodem {
 static struct dmodem port;
 static bool destroying = false;
 static pj_pool_t *pool;
+static int ctrl_sock = -1;
+static pjsua_call_id current_call = PJSUA_INVALID_ID;
+static pjsua_acc_id acc_id;
+static char *sip_domain;
 
 static void error_exit(const char *title, pj_status_t status) {
 	pjsua_perror(__FILE__, title, status);
@@ -76,29 +82,37 @@ static pj_status_t dmodem_get_frame(pjmedia_port *this_port, pjmedia_frame *fram
 }
 
 static pj_status_t dmodem_on_destroy(pjmedia_port *this_port) {
-	printf("destroy\n");
-	exit(-1);
+        printf("destroy\n");
+        exit(-1);
 }
 
 /* Callback called by the library when call's state has changed */
 static void on_call_state(pjsua_call_id call_id, pjsip_event *e) {
-	pjsua_call_info ci;
+        pjsua_call_info ci;
 
 	PJ_UNUSED_ARG(e);
 
-	pjsua_call_get_info(call_id, &ci);
-	PJ_LOG(3,(__FILE__, "Call %d state=%.*s", call_id,
-				(int)ci.state_text.slen,
-				ci.state_text.ptr));
+        pjsua_call_get_info(call_id, &ci);
+        PJ_LOG(3,(__FILE__, "Call %d state=%.*s", call_id,
+                                (int)ci.state_text.slen,
+                                ci.state_text.ptr));
 
-	if (ci.state == PJSIP_INV_STATE_DISCONNECTED) {
-		close(port.sock);
-		if (!destroying) {
-			destroying = true;
-			pjsua_destroy();
-			exit(0);
-		}
-	}
+        if (ci.state == PJSIP_INV_STATE_CONFIRMED) {
+                if (ctrl_sock != -1)
+                        write(ctrl_sock, "CONNECT\n", 8);
+        }
+
+        if (ci.state == PJSIP_INV_STATE_DISCONNECTED) {
+                if (ctrl_sock != -1)
+                        write(ctrl_sock, "DISCONNECT\n", 11);
+                current_call = PJSUA_INVALID_ID;
+                close(port.sock);
+                if (!destroying) {
+                        destroying = true;
+                        pjsua_destroy();
+                        exit(0);
+                }
+        }
 }
 
 /* Callback called by the library when call's media state has changed */
@@ -122,141 +136,162 @@ static void on_call_media_state(pjsua_call_id call_id) {
 	}
 }
 
+static void on_incoming_call(pjsua_acc_id acc_id, pjsua_call_id call_id, pjsip_rx_data *rdata) {
+        PJ_UNUSED_ARG(acc_id);
+        PJ_UNUSED_ARG(rdata);
+        current_call = call_id;
+        if (ctrl_sock != -1)
+                write(ctrl_sock, "RING\n", 5);
+}
+
 
 int main(int argc, char *argv[]) {
-	pjsua_acc_id acc_id;
-	pj_status_t status;
+        pj_status_t status;
 
-	if (argc != 3) {
-		return -1;
-	}
+        if (argc < 4)
+                return -1;
 
-	signal(SIGPIPE,SIG_IGN);
+        signal(SIGPIPE,SIG_IGN);
 
-	char *dialstr = argv[1];
+        bool listen_only = strcmp(argv[1], "-") == 0;
+        char *dialstr = listen_only ? NULL : argv[1];
+        port.sock = atoi(argv[2]);
+        ctrl_sock = atoi(argv[3]);
 
-	char *sip_user = getenv("SIP_LOGIN");
-	if (!sip_user) {
-		return -1;
-	}
-	char *sip_domain = strchr(sip_user,'@');
-	if (!sip_domain) {
-		return -1;
-	}
-	*sip_domain++ = '\0';
-	char *sip_pass = strchr(sip_user,':');
-	if (!sip_pass) {
-		return -1;
-	}
-	*sip_pass++ = '\0';
+        char *sip_login = getenv("SIP_LOGIN");
+        if (!sip_login)
+                return -1;
+        char *user = sip_login;
+        char *domain = strchr(user,'@');
+        if (!domain)
+                return -1;
+        *domain++ = '\0';
+        char *pass = strchr(user,':');
+        if (!pass)
+                return -1;
+        *pass++ = '\0';
+        sip_domain = domain;
 
-	status = pjsua_create();
-	if (status != PJ_SUCCESS) error_exit("Error in pjsua_create()", status);
+        status = pjsua_create();
+        if (status != PJ_SUCCESS) error_exit("Error in pjsua_create()", status);
 
-	/* Init pjsua */
-	{
-		pjsua_config cfg;
-		pjsua_logging_config log_cfg;
-		pjsua_media_config med_cfg;
+        {
+                pjsua_config cfg;
+                pjsua_logging_config log_cfg;
+                pjsua_media_config med_cfg;
 
-		pjsua_config_default(&cfg);
-		cfg.cb.on_call_media_state = &on_call_media_state;
-		cfg.cb.on_call_state = &on_call_state;
+                pjsua_config_default(&cfg);
+                cfg.cb.on_call_media_state = &on_call_media_state;
+                cfg.cb.on_call_state = &on_call_state;
+                cfg.cb.on_incoming_call = &on_incoming_call;
 
-		pjsua_logging_config_default(&log_cfg);
-		log_cfg.console_level = 4;
+                pjsua_logging_config_default(&log_cfg);
+                log_cfg.console_level = 4;
 
-		pjsua_media_config_default(&med_cfg);
-		med_cfg.no_vad = true;
-		med_cfg.ec_tail_len = 0;
-		med_cfg.jb_max = 2000;
-//		med_cfg.jb_init = 200;
-		med_cfg.audio_frame_ptime = 5;
+                pjsua_media_config_default(&med_cfg);
+                med_cfg.no_vad = true;
+                med_cfg.ec_tail_len = 0;
+                med_cfg.jb_max = 2000;
+                med_cfg.audio_frame_ptime = 5;
 
-		status = pjsua_init(&cfg, &log_cfg, &med_cfg);
-		if (status != PJ_SUCCESS) error_exit("Error in pjsua_init()", status);
-	}
+                status = pjsua_init(&cfg, &log_cfg, &med_cfg);
+                if (status != PJ_SUCCESS) error_exit("Error in pjsua_init()", status);
+        }
 
-	pjsua_set_ec(0,0); // maybe?
-	pjsua_set_null_snd_dev();
-	
-	/* g711 only */
-	pjsua_codec_info codecs[32];
-	unsigned count = sizeof(codecs)/sizeof(*codecs);
-	pjsua_enum_codecs(codecs,&count);
-	for (int i=0; i<count; i++) {
-		int pri = 0;
-		if (pj_strcmp2(&codecs[i].codec_id,"PCMU/8000/1") == 0) {
-			pri = 1;
-		} else if (pj_strcmp2(&codecs[i].codec_id,"PCMA/8000/1") == 0) {
-			pri = 2;
-		}
-		pjsua_codec_set_priority(&codecs[i].codec_id, pri);
-//		printf("codec: %s %d\n",pj_strbuf(&codecs[i].codec_id),pri);
-	}
+        pjsua_set_ec(0,0);
+        pjsua_set_null_snd_dev();
 
-	/* Add UDP transport. */
-	{
-		pjsua_transport_config cfg;
+        pjsua_codec_info codecs[32];
+        unsigned count = sizeof(codecs)/sizeof(*codecs);
+        pjsua_enum_codecs(codecs,&count);
+        for (int i=0; i<count; i++) {
+                int pri = 0;
+                if (pj_strcmp2(&codecs[i].codec_id,"PCMU/8000/1") == 0)
+                        pri = 1;
+                else if (pj_strcmp2(&codecs[i].codec_id,"PCMA/8000/1") == 0)
+                        pri = 2;
+                pjsua_codec_set_priority(&codecs[i].codec_id, pri);
+        }
 
-		pjsua_transport_config_default(&cfg);
-		cfg.port = 5060;
-		status = pjsua_transport_create(PJSIP_TRANSPORT_UDP, &cfg, NULL);
-		if (status != PJ_SUCCESS) error_exit("Error creating transport", status);
-	}
+        {
+                pjsua_transport_config cfg;
+                pjsua_transport_config_default(&cfg);
+                cfg.port = 5060;
+                status = pjsua_transport_create(PJSIP_TRANSPORT_UDP, &cfg, NULL);
+                if (status != PJ_SUCCESS) error_exit("Error creating transport", status);
+        }
 
-	pj_caching_pool cp;
-	pj_caching_pool_init(&cp, NULL, 1024*1024);
-	pool = pj_pool_create(&cp.factory, "pool1", 4000, 4000, NULL);
+        pj_caching_pool cp;
+        pj_caching_pool_init(&cp, NULL, 1024*1024);
+        pool = pj_pool_create(&cp.factory, "pool1", 4000, 4000, NULL);
 
-	pj_str_t name = pj_str("dmodem");
-	
-	memset(&port,0,sizeof(port));
-	port.sock = atoi(argv[2]); // inherited from parent
-	pjmedia_port_info_init(&port.base.info, &name, SIGNATURE, 9600, 1, 16, 192);
-	port.base.put_frame = dmodem_put_frame;
-	port.base.get_frame = dmodem_get_frame;
-	port.base.on_destroy = dmodem_on_destroy;
+        pj_str_t name = pj_str("dmodem");
+        memset(&port,0,sizeof(port));
+        pjmedia_port_info_init(&port.base.info, &name, SIGNATURE, 9600, 1, 16, 192);
+        port.base.put_frame = dmodem_put_frame;
+        port.base.get_frame = dmodem_get_frame;
+        port.base.on_destroy = dmodem_on_destroy;
 
-	char buf[384];
-	memset(buf,0,sizeof(buf));
-	write(port.sock, buf, sizeof(buf));
+        char buf[384];
+        memset(buf,0,sizeof(buf));
+        write(port.sock, buf, sizeof(buf));
 
-	/* Initialization is done, now start pjsua */
-	status = pjsua_start();
-	if (status != PJ_SUCCESS) error_exit("Error starting pjsua", status);
+        status = pjsua_start();
+        if (status != PJ_SUCCESS) error_exit("Error starting pjsua", status);
 
-	{
-		pjsua_acc_config cfg;
-		pjsua_acc_config_default(&cfg);
-		snprintf(buf,sizeof(buf),"sip:%s@%s",sip_user,sip_domain);
-		pj_strdup2(pool,&cfg.id,buf);
-		snprintf(buf,sizeof(buf),"sip:%s",sip_domain);
-		pj_strdup2(pool,&cfg.reg_uri,buf);
-		cfg.register_on_acc_add = false;
-		cfg.cred_count = 1;
-		cfg.cred_info[0].realm = pj_str("*");
-		cfg.cred_info[0].scheme = pj_str("digest");
-		cfg.cred_info[0].username = pj_str(sip_user);
-		cfg.cred_info[0].data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
-		cfg.cred_info[0].data = pj_str(sip_pass);
+        {
+                pjsua_acc_config cfg;
+                pjsua_acc_config_default(&cfg);
+                snprintf(buf,sizeof(buf),"sip:%s@%s",user,domain);
+                pj_strdup2(pool,&cfg.id,buf);
+                snprintf(buf,sizeof(buf),"sip:%s",domain);
+                pj_strdup2(pool,&cfg.reg_uri,buf);
+                cfg.register_on_acc_add = true;
+                cfg.cred_count = 1;
+                cfg.cred_info[0].realm = pj_str("*");
+                cfg.cred_info[0].scheme = pj_str("digest");
+                cfg.cred_info[0].username = pj_str(user);
+                cfg.cred_info[0].data_type = PJSIP_CRED_DATA_PLAIN_PASSWD;
+                cfg.cred_info[0].data = pj_str(pass);
 
-		status = pjsua_acc_add(&cfg, PJ_TRUE, &acc_id);
-		if (status != PJ_SUCCESS) error_exit("Error adding account", status);
-	}
+                status = pjsua_acc_add(&cfg, PJ_TRUE, &acc_id);
+                if (status != PJ_SUCCESS) error_exit("Error adding account", status);
+        }
 
-	snprintf(buf,sizeof(buf),"sip:%s@%s",dialstr,sip_domain);
-	printf("calling %s\n",buf);
-	pj_str_t uri = pj_str(buf);
-	
-	pjsua_call_id callid;
-	status = pjsua_call_make_call(acc_id, &uri, 0, NULL, NULL, &callid);
-	if (status != PJ_SUCCESS) error_exit("Error making call", status);
+        if (!listen_only && dialstr) {
+                snprintf(buf,sizeof(buf),"sip:%s@%s",dialstr,domain);
+                pj_str_t uri = pj_str(buf);
+                status = pjsua_call_make_call(acc_id, &uri, 0, NULL, NULL, &current_call);
+                if (status != PJ_SUCCESS) error_exit("Error making call", status);
+        }
 
-	struct timespec ts = {100, 0};
-	while(1) {
-		nanosleep(&ts,NULL);
-	}
+        while(1) {
+                fd_set rset;
+                FD_ZERO(&rset);
+                FD_SET(ctrl_sock,&rset);
+                select(ctrl_sock+1,&rset,NULL,NULL,NULL);
+                if (FD_ISSET(ctrl_sock,&rset)) {
+                        int n = read(ctrl_sock, buf, sizeof(buf)-1);
+                        if (n <= 0)
+                                break;
+                        buf[n] = '\0';
+                        char *nl = strchr(buf,'\n');
+                        if (nl) *nl = '\0';
+                        if (strncmp(buf,"ANSWER",6) == 0) {
+                                if (current_call != PJSUA_INVALID_ID)
+                                        pjsua_call_answer(current_call, 200, NULL, NULL);
+                        } else if (strncmp(buf,"HANGUP",6) == 0) {
+                                if (current_call != PJSUA_INVALID_ID)
+                                        pjsua_call_hangup(current_call, 0, NULL, NULL);
+                        } else if (strncmp(buf,"DIAL ",5) == 0) {
+                                char uri_buf[384];
+                                snprintf(uri_buf,sizeof(uri_buf),"sip:%s@%s",buf+5,sip_domain);
+                                pj_str_t uri = pj_str(uri_buf);
+                                status = pjsua_call_make_call(acc_id, &uri, 0, NULL, NULL, &current_call);
+                                if (status != PJ_SUCCESS) error_exit("Error making call", status);
+                        }
+                }
+        }
 
-	return 0;
+        return 0;
 }

--- a/slmodemd/Makefile
+++ b/slmodemd/Makefile
@@ -20,6 +20,7 @@ CC:= gcc
 else
 # SUPPORT_ALSA:=1
 CC:= gcc -m32
+CFLAGS+= -I/usr/include/x86_64-linux-gnu
 endif
 
 RM:= rm -f

--- a/slmodemd/modem.c
+++ b/slmodemd/modem.c
@@ -53,6 +53,9 @@
 #include <modem.h>
 #include <modem_debug.h>
 
+__attribute__((weak)) void dmodem_command(const char *cmd) {
+        (void)cmd;
+}
 
 #define XMIT_SIZE 4096
 
@@ -423,7 +426,9 @@ static void run_modem_stop(struct modem *m)
 
 static void modem_hup(struct modem *m, unsigned local)
 {
-	MODEM_DBG("modem_hup...%d\n",m->state);
+        MODEM_DBG("modem_hup...%d\n",m->state);
+        if (local)
+                dmodem_command("HANGUP\n");
 	switch(m->state) {
 	case STATE_MODEM_IDLE:
 		return;
@@ -1568,6 +1573,7 @@ int modem_recv_from_tty(struct modem *m, char *buf, int n)
 int modem_answer(struct modem *m)
 {
         MODEM_DBG("modem answer...\n");
+        dmodem_command("ANSWER\n");
         if ( m->dp ) {
                 MODEM_ERR("dp %d is already exists.\n", m->dp->id);
                 return -1;
@@ -1613,14 +1619,22 @@ static int modem_dial_start(struct modem *m)
 
 int modem_dial(struct modem *m)
 {
-	int ret;
+        int ret;
         MODEM_DBG("modem dial: %s...\n", m->dial_string);
-	m->dp_requested = 0;
-	m->automode_requested = 0;
- 	ret = modem_dial_start(m);
-	if(ret)
-		return -1;
-	return modem_start(m);
+        char cmd[160];
+        snprintf(cmd,sizeof(cmd),"DIAL %s\n", m->dial_string);
+        dmodem_command(cmd);
+        m->dp_requested = 0;
+        m->automode_requested = 0;
+        ret = modem_dial_start(m);
+        if(ret)
+                return -1;
+        return modem_start(m);
+}
+
+void modem_remote_hangup(struct modem *m)
+{
+        modem_hup(m,0);
 }
 
 

--- a/slmodemd/modem.h
+++ b/slmodemd/modem.h
@@ -430,6 +430,8 @@ extern void modem_error  (struct modem *m);
 extern void modem_ring   (struct modem *m);
 extern void modem_event  (struct modem *m);
 extern void modem_process(struct modem *m,void *in,void *out,int cnt);
+void dmodem_command(const char *cmd);
+void modem_remote_hangup(struct modem *m);
 
 /* packers && EC */ // FIXME: improve interface
 extern void modem_async_start(struct modem *m);

--- a/slmodemd/modem_main.c
+++ b/slmodemd/modem_main.c
@@ -135,6 +135,12 @@ struct device_struct {
 
 static char  inbuf[4096];
 static char outbuf[4096];
+static int control_fd = -1;
+
+void dmodem_command(const char *cmd) {
+        if (control_fd != -1)
+                write(control_fd, cmd, strlen(cmd));
+}
 
 
 /*
@@ -615,53 +621,66 @@ struct modem_driver mdm_modem_driver = {
 
 static int socket_start (struct modem *m)
 {
-	struct device_struct *dev = m->dev_data;
-	int ret;
-	DBG("socket_start...\n");
+        struct device_struct *dev = m->dev_data;
+        int ret;
+        DBG("socket_start...\n");
 
-	int sockets[2];
+        int sockets[2];
+        int ctrls[2];
 
-	if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == -1) {
-		perror("socketpair");
-		exit(-1);
-	}
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) == -1) {
+                perror("socketpair");
+                exit(-1);
+        }
+        if (socketpair(AF_UNIX, SOCK_STREAM, 0, ctrls) == -1) {
+                perror("socketpair");
+                exit(-1);
+        }
 
-	pid_t pid = fork();
-	if (pid == -1) {
-		perror("fork");
-		exit(-1);
-	}
-	if (pid == 0) { // child
-		char str[16];
-		snprintf(str,sizeof(str),"%d",sockets[0]);
-		close(sockets[1]);
-		execl(modem_exec,modem_exec,m->dial_string,str,NULL);
-	} else {
-		close(sockets[0]);
-		dev->fd = sockets[1];
-		dev->delay = 0;
-		ret = 192*2;
-		memset(outbuf, 0 , ret);
-		ret = write(dev->fd, outbuf, ret);
-		DBG("done delay thing\n");
-		if (ret < 0) {
-			close(dev->fd);
-			dev->fd = -1;
-			return ret;
-		}
-		dev->delay = ret/2;
-	}
-	return 0;
+        pid_t pid = fork();
+        if (pid == -1) {
+                perror("fork");
+                exit(-1);
+        }
+        if (pid == 0) { // child
+                char str[16], ctrlstr[16];
+                snprintf(str,sizeof(str),"%d",sockets[0]);
+                snprintf(ctrlstr,sizeof(ctrlstr),"%d",ctrls[0]);
+                close(sockets[1]);
+                close(ctrls[1]);
+                execl(modem_exec,modem_exec,"-",str,ctrlstr,NULL);
+        } else {
+                close(sockets[0]);
+                close(ctrls[0]);
+                dev->fd = sockets[1];
+                control_fd = ctrls[1];
+                dev->delay = 0;
+                ret = 192*2;
+                memset(outbuf, 0 , ret);
+                ret = write(dev->fd, outbuf, ret);
+                DBG("done delay thing\n");
+                if (ret < 0) {
+                        close(dev->fd);
+                        dev->fd = -1;
+                        return ret;
+                }
+                dev->delay = ret/2;
+        }
+        return 0;
 }
 
 static int socket_stop (struct modem *m)
 {
-	struct device_struct *dev = m->dev_data;
-	DBG("socket_stop...\n");
-	close(dev->fd);
-	dev->fd = -1;
-	wait(NULL); // for exec'ed child
-	return 0;
+        struct device_struct *dev = m->dev_data;
+        DBG("socket_stop...\n");
+        close(dev->fd);
+        dev->fd = -1;
+        if (control_fd != -1) {
+                close(control_fd);
+                control_fd = -1;
+        }
+        wait(NULL); // for exec'ed child
+        return 0;
 }
 
 static int socket_ioctl(struct modem *m, unsigned int cmd, unsigned long arg)
@@ -891,12 +910,16 @@ static int modem_run(struct modem *m, struct device_struct *dev)
                 tmo.tv_sec = 1;
                 tmo.tv_usec= 0;
                 FD_ZERO(&rset);
-		FD_ZERO(&eset);
-		if(m->started)
-			FD_SET(dev->fd,&rset);
+                FD_ZERO(&eset);
+                if(m->started)
+                        FD_SET(dev->fd,&rset);
 
-		FD_SET(dev->fd,&eset);
-		max_fd = dev->fd;
+                FD_SET(dev->fd,&eset);
+                max_fd = dev->fd;
+                if(control_fd != -1) {
+                        FD_SET(control_fd,&rset);
+                        if (control_fd > max_fd) max_fd = control_fd;
+                }
 		
 		if(pty_closed && close_count > 0) {
 			if(!m->started ||
@@ -917,8 +940,19 @@ static int modem_run(struct modem *m, struct device_struct *dev)
                         return ret;
                 }
 
-		if ( ret == 0 )
-			continue;
+                if ( ret == 0 )
+                        continue;
+
+                if(control_fd != -1 && FD_ISSET(control_fd,&rset)) {
+                        int n = read(control_fd, inbuf, sizeof(inbuf)-1);
+                        if (n > 0) {
+                                inbuf[n] = '\0';
+                                if (!strncmp(inbuf,"RING",4))
+                                        modem_ring(m);
+                                else if (!strncmp(inbuf,"DISCONNECT",10))
+                                        modem_remote_hangup(m);
+                        }
+                }
 
 		if(FD_ISSET(dev->fd, &eset)) {
 			unsigned stat;


### PR DESCRIPTION
## Summary
- Allow `d-modem` to register for inbound SIP calls and exchange call control over a dedicated socket
- Extend slmodemd with a control channel and helper to relay RING/ANSWER/HANGUP events
- Document new ability to receive and answer calls, including example of two clients calling each other
- Adjust Makefile include path so 32-bit `slmodemd` builds correctly on x86_64 systems
- Require the original 32-bit SmartLink DSP object and drop the stub fallback

## Testing
- `apt-get install -y gcc-multilib libc6-dev-i386`
- `make -C slmodemd`
- `./slmodemd/slmodemd -d0 -e ./d-modem` *(fails: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_68a78db85e1c8326a677cdf61f1e5c67